### PR TITLE
Fix the remaining incorrect symbolic link

### DIFF
--- a/examples/fsm/gensig1/.ocamlinit
+++ b/examples/fsm/gensig1/.ocamlinit
@@ -1,1 +1,1 @@
-../../../etc/toplevel.init
+../../../etc/toplevel.ini


### PR DESCRIPTION
This is the follow-up fix for commit c69f3ee.
There is a missing reference to the old file in the examples, that prevents `dune subst` used in the opam installation.